### PR TITLE
feat: add populateAssets command and update args type

### DIFF
--- a/packages/azion/src/cli/args.ts
+++ b/packages/azion/src/cli/args.ts
@@ -24,6 +24,10 @@ export type Arguments = (
       assetsDir: string;
       cacheDir: string;
     }
+  | {
+      command: "populateAssets";
+      assetsDir: string;
+    }
 ) & { outputDir?: string };
 
 // TODO: review this when azion.config.js contains this information
@@ -80,8 +84,17 @@ export function getArgs(): Arguments {
         cacheDir: CACHE_DIR,
       };
 
+    case "populateAssets":
+      return {
+        command: "populateAssets",
+        outputDir,
+        assetsDir: ASSETS_DIR,
+      };
+
     default:
-      throw new Error("Error: invalid command, expected 'build' | 'preview' | 'deploy' | 'populateCache'");
+      throw new Error(
+        "Error: invalid command, expected 'build' | 'preview' | 'deploy' | 'populateCache' | 'populateAssets'"
+      );
   }
 }
 

--- a/packages/azion/src/cli/commands/populate-assets.ts
+++ b/packages/azion/src/cli/commands/populate-assets.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+
+import { BuildOptions } from "@opennextjs/aws/build/helper.js";
+
+import { copyAssets } from "../../core/utils/copy-assets.js";
+
+export async function populateAssets(options: BuildOptions, previewOptions: { assetsDir: string }) {
+  // Copy static assets to the cache directory
+  copyAssets(path.join(options.outputDir, "assets"), path.join(previewOptions.assetsDir));
+}

--- a/packages/azion/src/index.ts
+++ b/packages/azion/src/index.ts
@@ -14,6 +14,7 @@ import logger from "@opennextjs/aws/logger.js";
 import { Arguments, getArgs } from "./cli/args.js";
 import { build } from "./cli/commands/build.js";
 import { deploy } from "./cli/commands/deploy.js";
+import { populateAssets } from "./cli/commands/populate-assets.js";
 import { populateCache } from "./cli/commands/populate-cache.js";
 import { preview } from "./cli/commands/preview.js";
 import { createOpenNextConfigIfNotExistent, ensureAzionConfig } from "./core/build/utils/index.js";
@@ -52,6 +53,8 @@ async function runCommand(args: Arguments) {
       return deploy(options, config, args);
     case "populateCache":
       return populateCache(options, config, args);
+    case "populateAssets":
+      return populateAssets(options, args);
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new `populateAssets` command to the Azion CLI, which facilitates copying static assets to a specified directory. The key changes include updates to the argument structure, command handling logic, and the addition of a new utility function for asset population.

### Addition of the `populateAssets` command:

* **Argument structure update**: Added support for the new `populateAssets` command in the `Arguments` type and the `getArgs` function to handle this command's specific parameters (`assetsDir` and `outputDir`). (`packages/azion/src/cli/args.ts`, [[1]](diffhunk://#diff-9922c6815de9fedb14c6eb7bd9c920e0d6fd513f04c5477a9be981fbfa734bbcR27-R30) [[2]](diffhunk://#diff-9922c6815de9fedb14c6eb7bd9c920e0d6fd513f04c5477a9be981fbfa734bbcR87-R97)
* **New command implementation**: Introduced the `populateAssets` function in a new file, `populate-assets.ts`, which uses the `copyAssets` utility to copy static assets to the specified directory. (`packages/azion/src/cli/commands/populate-assets.ts`, [packages/azion/src/cli/commands/populate-assets.tsR1-R10](diffhunk://#diff-a8754b2e8c2d06e5b0466ee47be7afa81216d1c72dce6d37578a9ffac822472dR1-R10))

### Integration with the CLI:

* **Command registration**: Registered the `populateAssets` command in the main CLI entry point by importing it and adding it to the `runCommand` function. (`packages/azion/src/index.ts`, [[1]](diffhunk://#diff-ca17a32e53bc964f1481a94e7a904cc635188ff4d8d1bd5156119459a9a91c00R17) [[2]](diffhunk://#diff-ca17a32e53bc964f1481a94e7a904cc635188ff4d8d1bd5156119459a9a91c00R56-R57)