### PR TITLE
fix: add prettier dependency

### DIFF
--- a/.changeset/few-squids-shop.md
+++ b/.changeset/few-squids-shop.md
@@ -1,0 +1,5 @@
+---
+"@aziontech/opennextjs-azion": patch
+---
+
+fix: add prettier as a dependency and update pnpm lockfile

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jcbsfilho @jotanarciso
+* @jcbsfilho @jotanarciso @pablodiehl

--- a/packages/azion/package.json
+++ b/packages/azion/package.json
@@ -60,6 +60,10 @@
     {
       "name": "João Narciso",
       "url": "https://jotanarciso.com"
+    },
+    {
+      "name": "pablodiehl",
+      "url": "https://github.com/pablodiehl"
     }
   ],
   "license": "MIT",

--- a/packages/azion/package.json
+++ b/packages/azion/package.json
@@ -72,6 +72,7 @@
     "@opennextjs/aws": "~3.6.0",
     "enquirer": "^2.4.1",
     "glob": "catalog:",
+    "prettier": "3.3.3",
     "ts-tqdm": "^0.8.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       glob:
         specifier: 'catalog:'
         version: 11.0.0
+      prettier:
+        specifier: 3.3.3
+        version: 3.3.3
       ts-tqdm:
         specifier: ^0.8.6
         version: 0.8.6


### PR DESCRIPTION
This pull request introduces a small but important change to the project dependencies. It adds `prettier` as a dependency and updates the `pnpm-lock.yaml` file accordingly.

Dependency updates:

* [`.changeset/few-squids-shop.md`](diffhunk://#diff-67f7960f9bb0c7765a6cdd91b545acd83b7f5abc44510c92af7236a413c8a0f6R1-R5): Documented the addition of `prettier` as a dependency and updated the pnpm lockfile.
* [`packages/azion/package.json`](diffhunk://#diff-bfb76b6c651764a2ab346de6ea5ab748acd0a9041c5890b313b24713c20d9625R75): Added `prettier` version `3.3.3` to the dependencies section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR101-R103): Included `prettier` with version `3.3.3` in the lockfile under `importers`.