### PR TITLE
feat: make assetsDir and cacheDir optional parameters with default values

### DIFF
--- a/.changeset/gentle-dancers-fetch.md
+++ b/.changeset/gentle-dancers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@aziontech/opennextjs-azion": patch
+---
+
+make assetsDir and cacheDir optional parameters with default values

--- a/packages/azion/src/cli/args.ts
+++ b/packages/azion/src/cli/args.ts
@@ -11,29 +11,26 @@ export type Arguments = (
       command: "build";
       skipNextBuild: boolean;
       minify: boolean;
+      assetsDir?: string;
     }
   | {
       command: "preview" | "deploy";
       passthroughArgs: string[];
-      assetsDir: string;
-      cacheDir: string;
+      assetsDir?: string;
+      cacheDir?: string;
       skipNextBuild: boolean;
       bundlerVersion?: string;
     }
   | {
       command: "populateCache";
-      assetsDir: string;
-      cacheDir: string;
+      assetsDir?: string;
+      cacheDir?: string;
     }
   | {
       command: "populateAssets";
-      assetsDir: string;
+      assetsDir?: string;
     }
 ) & { outputDir?: string };
-
-// TODO: review this when azion.config.js contains this information
-const ASSETS_DIR = ".edge/storage";
-const CACHE_DIR = ".edge/storage";
 
 export function getArgs(): Arguments {
   const { positionals, values } = parseArgs({
@@ -42,6 +39,8 @@ export function getArgs(): Arguments {
       output: { type: "string", short: "o" },
       noMinify: { type: "boolean", default: false },
       bundlerVersion: { type: "string", default: "latest" }, // Default to latest version
+      assetsDir: { type: "string", default: ".edge/storage" },
+      cacheDir: { type: "string", default: ".edge/storage" },
     },
     allowPositionals: true,
   });
@@ -63,8 +62,8 @@ export function getArgs(): Arguments {
         command: "preview",
         passthroughArgs: getPassthroughArgs(),
         outputDir,
-        assetsDir: ASSETS_DIR,
-        cacheDir: CACHE_DIR,
+        assetsDir: values.assetsDir,
+        cacheDir: values.cacheDir,
         bundlerVersion: values.bundlerVersion,
         skipNextBuild:
           values.skipBuild || ["1", "true", "yes"].includes(String(process.env.SKIP_NEXT_APP_BUILD)),
@@ -74,8 +73,8 @@ export function getArgs(): Arguments {
         command: "deploy",
         passthroughArgs: getPassthroughArgs(),
         outputDir,
-        assetsDir: ASSETS_DIR,
-        cacheDir: CACHE_DIR,
+        assetsDir: values.assetsDir,
+        cacheDir: values.cacheDir,
         bundlerVersion: values.bundlerVersion,
         skipNextBuild:
           values.skipBuild || ["1", "true", "yes"].includes(String(process.env.SKIP_NEXT_APP_BUILD)),
@@ -85,15 +84,14 @@ export function getArgs(): Arguments {
       return {
         command: "populateCache",
         outputDir,
-        assetsDir: ASSETS_DIR,
-        cacheDir: CACHE_DIR,
+        cacheDir: values.cacheDir,
       };
 
     case "populateAssets":
       return {
         command: "populateAssets",
         outputDir,
-        assetsDir: ASSETS_DIR,
+        assetsDir: values.assetsDir,
       };
 
     default:

--- a/packages/azion/src/cli/commands/deploy.ts
+++ b/packages/azion/src/cli/commands/deploy.ts
@@ -12,8 +12,8 @@ export async function deploy(
   options: BuildOptions,
   _config: OpenNextConfig,
   deployOptions: {
-    assetsDir: string;
-    cacheDir: string;
+    assetsDir?: string;
+    cacheDir?: string;
     bundlerVersion?: string;
     skipNextBuild: boolean;
     passthroughArgs: string[];

--- a/packages/azion/src/cli/commands/populate-assets.ts
+++ b/packages/azion/src/cli/commands/populate-assets.ts
@@ -4,7 +4,7 @@ import { BuildOptions } from "@opennextjs/aws/build/helper.js";
 
 import { copyAssets } from "../../core/utils/copy-assets.js";
 
-export async function populateAssets(options: BuildOptions, previewOptions: { assetsDir: string }) {
+export async function populateAssets(options: BuildOptions, previewOptions: { assetsDir?: string }) {
   // Copy static assets to the cache directory
-  copyAssets(path.join(options.outputDir, "assets"), path.join(previewOptions.assetsDir));
+  copyAssets(path.join(options.outputDir, "assets"), path.join(previewOptions.assetsDir!));
 }

--- a/packages/azion/src/cli/commands/populate-cache.ts
+++ b/packages/azion/src/cli/commands/populate-cache.ts
@@ -77,13 +77,13 @@ export function getCacheAssets(opts: BuildOptions): CacheAsset[] {
   return assets;
 }
 
-function populateStaticAssetsIncrementalCache(options: BuildOptions, cacheDir: string) {
+function populateStaticAssetsIncrementalCache(options: BuildOptions, cacheDir?: string) {
   logger.info("Populating cache...");
-  const storageCacheDir = path.join(cacheDir, STATIC_ASSETS_CACHE_DIR);
+  const storageCacheDir = path.join(cacheDir!, STATIC_ASSETS_CACHE_DIR);
   if (existsSync(storageCacheDir)) {
     rmSync(storageCacheDir, { recursive: true, force: true });
   }
-  cpSync(path.join(options.outputDir, "cache"), path.join(cacheDir, STATIC_ASSETS_CACHE_DIR), {
+  cpSync(path.join(options.outputDir, "cache"), path.join(cacheDir!, STATIC_ASSETS_CACHE_DIR), {
     recursive: true,
   });
   logger.info(`Successfully populated cache`);
@@ -92,7 +92,7 @@ function populateStaticAssetsIncrementalCache(options: BuildOptions, cacheDir: s
 export async function populateCache(
   options: BuildOptions,
   config: OpenNextConfig,
-  populateCacheOptions: { cacheDir: string }
+  populateCacheOptions: { cacheDir?: string }
 ) {
   const { incrementalCache } = config.default.override ?? {};
 

--- a/packages/azion/src/cli/commands/preview.ts
+++ b/packages/azion/src/cli/commands/preview.ts
@@ -12,8 +12,8 @@ export async function preview(
   options: BuildOptions,
   _config: OpenNextConfig,
   previewOptions: {
-    assetsDir: string;
-    cacheDir: string;
+    assetsDir?: string;
+    cacheDir?: string;
     bundlerVersion?: string;
     skipNextBuild: boolean;
     passthroughArgs: string[];

--- a/packages/azion/src/core/runtime/worker.ts
+++ b/packages/azion/src/core/runtime/worker.ts
@@ -8,6 +8,7 @@
 import { runWithAzionRequestContext } from "./azion/init.js";
 
 // Azion Storage API
+// TODO: future receive from azion env
 const bucketName = (globalThis as any)?.AZION_BUCKET_NAME ?? "";
 const bucketPrefix = (globalThis as any)?.AZION_BUCKET_PREFIX ?? "";
 const InstanceStorage = new (globalThis as any).Azion.Storage(bucketName);
@@ -23,6 +24,7 @@ export default {
         CACHE_API_STORAGE_NAME: (globalThis as any).AZION_CACHE_API_STORAGE_NAME ?? "nextjs_cache",
         Storage: InstanceStorage,
       },
+      // TODO: future receive from azion env
       ASSETS: {
         fetch: getStorageAsset,
       },


### PR DESCRIPTION
This pull request updates the handling of the `assetsDir` and `cacheDir` options throughout the Azion CLI codebase to make them optional and configurable, rather than always required and hardcoded. This provides more flexibility for users and prepares the code for future enhancements where these values may be provided by the environment or configuration files.

**Arguments and option handling improvements:**

* Made `assetsDir` and `cacheDir` optional in the `Arguments` type and all related command options, and updated their default values to `.edge/storage` in the CLI argument parser. [[1]](diffhunk://#diff-9922c6815de9fedb14c6eb7bd9c920e0d6fd513f04c5477a9be981fbfa734bbcR14-R43) [[2]](diffhunk://#diff-9922c6815de9fedb14c6eb7bd9c920e0d6fd513f04c5477a9be981fbfa734bbcL66-R66) [[3]](diffhunk://#diff-9922c6815de9fedb14c6eb7bd9c920e0d6fd513f04c5477a9be981fbfa734bbcL77-R77) [[4]](diffhunk://#diff-9922c6815de9fedb14c6eb7bd9c920e0d6fd513f04c5477a9be981fbfa734bbcL88-R94)
* Updated the signatures of the `deploy`, `preview`, `populateAssets`, and `populateCache` command functions to accept optional `assetsDir` and `cacheDir` parameters. [[1]](diffhunk://#diff-e0f4ab751ac492536de8cf077543d175da607b90097d97e224a799e39aa82448L15-R16) [[2]](diffhunk://#diff-4444f8c71bc90f3be8ac4a68038070b53cb500ea52a2a5496c8a716271e0ca94L15-R16) [[3]](diffhunk://#diff-a8754b2e8c2d06e5b0466ee47be7afa81216d1c72dce6d37578a9ffac822472dL7-R9) [[4]](diffhunk://#diff-e376cb1b10e5803ab947fbc8ea6e31e86b189d67caf28902149440fb19d0034eL95-R95)

**Internal usage adjustments:**

* Updated internal function calls to use the possibly undefined `assetsDir` and `cacheDir` values, using non-null assertions where necessary, and adjusted logic to handle these as optional. [[1]](diffhunk://#diff-a8754b2e8c2d06e5b0466ee47be7afa81216d1c72dce6d37578a9ffac822472dL7-R9) [[2]](diffhunk://#diff-e376cb1b10e5803ab947fbc8ea6e31e86b189d67caf28902149440fb19d0034eL80-R86)

**Preparations for future environment-driven configuration:**

* Added TODO comments and logic in `worker.ts` to indicate that storage configuration (such as bucket names and prefixes) will be sourced from the Azion environment in the future. [[1]](diffhunk://#diff-a2f77a05a69616aa0e7181da149aec9ae0375bfc5d21a506490e5b65c19d0a0cR11) [[2]](diffhunk://#diff-a2f77a05a69616aa0e7181da149aec9ae0375bfc5d21a506490e5b65c19d0a0cR27)