### PR TITLE
fix: clone request before passing to middleware to prevent stream consumption errors

### DIFF
--- a/.changeset/flat-doors-pump.md
+++ b/.changeset/flat-doors-pump.md
@@ -1,0 +1,5 @@
+---
+"@aziontech/opennextjs-azion": patch
+---
+
+clone request before passing to middleware

--- a/packages/azion/src/core/runtime/worker.ts
+++ b/packages/azion/src/core/runtime/worker.ts
@@ -78,10 +78,8 @@ const requestHandler = async (request: Request, env: AzionEnv, ctx: ExecutionCon
   // - `Request`s are handled by the Next server
   // @ts-expect-error: resolved by bundler build
   const { handler: middlewareModule } = await import("./middleware/handler.mjs");
-  const reqOrResp = await middlewareModule(request, env, ctx).catch((e: Error) => {
-    console.error(e);
-    return new Response("Internal Server Error", { status: 500 });
-  });
+  const cloneRequest = request.clone();
+  const reqOrResp = await middlewareModule(cloneRequest, env, ctx);
 
   if (reqOrResp instanceof Response) {
     return reqOrResp;


### PR DESCRIPTION
This pull request introduces a patch to the `@aziontech/opennextjs-azion` package, focusing on how requests are passed to middleware in the Azion worker runtime. The main change ensures that the incoming `Request` object is cloned before being handed off to the middleware, which can help prevent side effects when the request is read or modified by the middleware.

Request handling improvements:

* The `requestHandler` in `packages/azion/src/core/runtime/worker.ts` now clones the incoming `Request` before passing it to the middleware, ensuring the original request remains unchanged and preventing potential issues if the middleware reads the request body.
* Updated the changeset file `.changeset/flat-doors-pump.md` to document this patch and its rationale.