### PR TITLE
v1.0.0 - First Major Release (Unstable)

### DIFF
--- a/.changeset/old-countries-boil.md
+++ b/.changeset/old-countries-boil.md
@@ -1,0 +1,9 @@
+---
+"@aziontech/opennextjs-azion": major
+---
+
+v1.0.0 - First Major Release (Unstable)
+
+Initial unstable release of OpenNext.js for Azion
+
+This marks the first major version of @aziontech/opennextjs-azion, an adapter that enables deployment of Next.js applications to Azion's platform.


### PR DESCRIPTION
This pull request introduces the initial unstable release of the `@aziontech/opennextjs-azion` package, marking its first major version. The package serves as an adapter for deploying Next.js applications to Azion's platform.

Release announcement:

* Added a changeset file `.changeset/old-countries-boil.md` documenting the v1.0.0 major release of `@aziontech/opennextjs-azion`, highlighting its purpose as an adapter for Next.js deployments on Azion.