### PR TITLE
chore: enforce pnpm version 9+ and strict engine requirements

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+package-manager-strict=true

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "code:checks": "pnpm prettier:check && pnpm lint:check && pnpm ts:check",
     "install-playwright": "playwright install --with-deps",
     "postinstall": "pnpm --filter @aziontech/opennextjs-azion build"
+  },
+  "packageManager": "pnpm@9.15.9",
+  "engines": {
+    "pnpm": ">=9.0.0"
   }
 }


### PR DESCRIPTION
This pull request introduces stricter package management and engine requirements to ensure consistent development environments. The main changes enforce the use of a specific version of `pnpm` and add configuration to prevent installing with unsupported package managers or versions.

Package management enforcement:

* Added `engine-strict=true` and `package-manager-strict=true` to `.npmrc` to require compatible package managers and engine versions.

Engine and package manager specification:

* Updated `package.json` to specify `pnpm@9.15.9` as the required package manager and added an `engines` field to enforce `pnpm` version `>=9.0.0`.