### PR TITLE
fix: runtime worker to correctly pass and control route preloading

### DIFF
--- a/.changeset/popular-nails-invite.md
+++ b/.changeset/popular-nails-invite.md
@@ -1,0 +1,5 @@
+---
+"@aziontech/opennextjs-azion": patch
+---
+
+fix: runtime worker to correctly pass and control route preloading

--- a/packages/azion/src/api/config.ts
+++ b/packages/azion/src/api/config.ts
@@ -3,7 +3,12 @@
  * Significant changes have been made to adapt it for use with Azion.
  */
 
-import { BaseOverride, LazyLoadedOverride, OpenNextConfig } from "@opennextjs/aws/types/open-next";
+import {
+  BaseOverride,
+  LazyLoadedOverride,
+  OpenNextConfig,
+  type RoutePreloadingBehavior,
+} from "@opennextjs/aws/types/open-next";
 import type { IncrementalCache, Queue, TagCache, Wrapper } from "@opennextjs/aws/types/overrides";
 
 import AzionWrapperEdge from "../core/overrides/wrapper/azion-wrapper-edge";
@@ -35,6 +40,13 @@ export type AzionOverrides = {
    * Sets the wrapper implementation.
    */
   wrapper?: Override<Wrapper>;
+
+  /**
+   * Route preloading behavior.
+   * Using a value other than "none" can result in higher CPU usage on cold starts.
+   * @default "none"
+   */
+  routePreloadingBehavior?: RoutePreloadingBehavior;
 };
 
 /**
@@ -44,7 +56,7 @@ export type AzionOverrides = {
  * @returns the OpenNext configuration object
  */
 export function defineAzionConfig(config: AzionOverrides = {}): OpenNextConfig {
-  const { incrementalCache, tagCache, queue, wrapper } = config;
+  const { incrementalCache, tagCache, queue, wrapper, routePreloadingBehavior } = config;
 
   return {
     default: {
@@ -56,6 +68,7 @@ export function defineAzionConfig(config: AzionOverrides = {}): OpenNextConfig {
         tagCache: resolveTagCache(tagCache),
         queue: resolveQueue(queue),
       },
+      routePreloadingBehavior,
     },
     // node:crypto is used to compute cache keys and node:stream is used to wrapper
     edgeExternals: ["node:crypto", "node:stream"],

--- a/packages/azion/src/core/runtime/worker.ts
+++ b/packages/azion/src/core/runtime/worker.ts
@@ -88,7 +88,7 @@ const requestHandler = async (request: Request, env: AzionEnv, ctx: ExecutionCon
   // @ts-expect-error: resolved by bundler build
   const { handler } = await import("./server-functions/default/handler.mjs");
 
-  return handler(request, env, ctx);
+  return handler(reqOrResp, env, ctx);
 };
 
 const getStorageAsset = async (request: Request | URL) => {


### PR DESCRIPTION
This pull request introduces a new configuration option for Azion deployments and makes a small fix to the runtime worker. The main change is the addition of the `routePreloadingBehavior` option to the Azion config, allowing users to control route preloading and potentially optimize cold start CPU usage. Additionally, a minor bug fix was made in the worker runtime to ensure the correct request object is passed to the handler.

### Runtime Bug Fix

* Fixed the runtime worker to correctly pass the `reqOrResp` object to the handler instead of the original `request`, ensuring proper request handling.

### Azion Configuration Enhancements

* Added an optional `routePreloadingBehavior` property to the `AzionOverrides` type, allowing users to specify route preloading behavior for Azion deployments. This helps control CPU usage during cold starts. [[1]](diffhunk://#diff-501b4d888aab69ee406bef88199e7e3bc0f6b9f265d495c33cae3408ac1d3706L6-R11) [[2]](diffhunk://#diff-501b4d888aab69ee406bef88199e7e3bc0f6b9f265d495c33cae3408ac1d3706R43-R49)
* Updated the `defineAzionConfig` function to accept and forward the new `routePreloadingBehavior` option, ensuring it is included in the generated config. [[1]](diffhunk://#diff-501b4d888aab69ee406bef88199e7e3bc0f6b9f265d495c33cae3408ac1d3706L47-R59) [[2]](diffhunk://#diff-501b4d888aab69ee406bef88199e7e3bc0f6b9f265d495c33cae3408ac1d3706R71)
