### PR TITLE
feat: add environment variable to bypass interactive prompts during build

### DIFF
--- a/.changeset/few-cows-travel.md
+++ b/.changeset/few-cows-travel.md
@@ -1,0 +1,5 @@
+---
+"@aziontech/opennextjs-azion": minor
+---
+
+feat: add environment variable to bypass interactive prompts during build

--- a/packages/azion/README.md
+++ b/packages/azion/README.md
@@ -75,3 +75,55 @@ To deploy your application to Azion using the Azion CLI, follow these steps:
    ```bash
    azion deploy --skip-build --local
    ```
+
+## Environment Variables
+
+The following environment variables can be used to customize the behavior of OpenNext for Azion:
+
+### `OPEN_NEXTJS_NO_INTERACTIVE_PROMPT`
+
+Controls whether interactive prompts are shown during the build process.
+
+- **Default**: `undefined` (prompts are shown)
+- **Values**:
+  - `"true"`: Automatically creates required configuration files without prompting
+  - Any other value or unset: Shows interactive prompts (default behavior)
+
+**Usage in CI/CD environments:**
+
+```bash
+# Automatically create config files without user interaction
+OPEN_NEXTJS_NO_INTERACTIVE_PROMPT=true azion build --preset opennextjs
+```
+
+**Or add to your `.env` file:**
+
+```env
+OPEN_NEXTJS_NO_INTERACTIVE_PROMPT=true
+```
+
+This is particularly useful for remote builds, CI/CD pipelines, and automated deployments where user interaction is not possible.
+
+### `NEXT_PRIVATE_DEBUG_CACHE`
+
+Enables detailed cache debugging logs for troubleshooting cache-related issues.
+
+- **Default**: `undefined` (no debug logs)
+- **Values**:
+  - `"true"`: Enables detailed cache operation logs
+  - Any other value or unset: Normal logging (default behavior)
+
+**Usage for debugging:**
+
+```bash
+# Enable cache debugging
+NEXT_PRIVATE_DEBUG_CACHE=true azion build --preset opennextjs
+```
+
+**Or add to your `.env` file:**
+
+```env
+NEXT_PRIVATE_DEBUG_CACHE=true
+```
+
+This will show detailed information about cache operations, including cache keys, storage operations, and any cache-related errors.

--- a/packages/azion/src/core/build/utils/create-config-files.ts
+++ b/packages/azion/src/core/build/utils/create-config-files.ts
@@ -7,6 +7,8 @@ import { getPackageRuntimeDirPath } from "../../utils/get-package-runtime-dir-pa
 /**
  * Creates a `open-next.config.ts` file for the user if it doesn't exist, but only after asking for the user's confirmation.
  *
+ * If OPEN_NEXTJS_NO_INTERACTIVE_PROMPT environment variable is set to 'true', automatically creates the file without asking.
+ *
  * If the user refuses an error is thrown (since the file is mandatory).
  *
  * @param sourceDir The source directory for the project
@@ -15,14 +17,27 @@ export async function createOpenNextConfigIfNotExistent(sourceDir: string): Prom
   const openNextConfigPath = join(sourceDir, "open-next.config.ts");
 
   if (!existsSync(openNextConfigPath)) {
-    const answer = await askConfirmation(
-      "Missing required `open-next.config.ts` file, do you want to create one?"
-    );
+    const ciAskConfirm = process.env.OPEN_NEXTJS_NO_INTERACTIVE_PROMPT;
+    let shouldCreate = true;
 
-    if (!answer) {
+    if (ciAskConfirm === "true") {
+      // Auto-create when OPEN_NEXTJS_NO_INTERACTIVE_PROMPT=true
+      console.log(
+        "Missing required `open-next.config.ts` file, creating one automatically (OPEN_NEXTJS_NO_INTERACTIVE_PROMPT=true)..."
+      );
+    } else {
+      // Ask for confirmation (original behavior)
+      shouldCreate = await askConfirmation(
+        "Missing required `open-next.config.ts` file, do you want to create one?"
+      );
+    }
+
+    if (!shouldCreate) {
       throw new Error("The `open-next.config.ts` file is required, aborting!");
     }
 
     cpSync(join(getPackageRuntimeDirPath(), "../../templates", "open-next.config.ts"), openNextConfigPath);
+
+    console.log("✅ Created `open-next.config.ts` file successfully.");
   }
 }


### PR DESCRIPTION
This pull request introduces a new environment variable to streamline the build process for OpenNext on Azion, especially in CI/CD and automated deployment scenarios. The main change allows bypassing interactive prompts when creating required configuration files, making the build process more automation-friendly. Additionally, documentation has been updated to explain the new and existing environment variables.

**Environment variable support for non-interactive builds:**

* Added support for the `OPEN_NEXTJS_NO_INTERACTIVE_PROMPT` environment variable in `create-config-files.ts`. When set to `"true"`, required config files are created automatically without user confirmation, which is useful for CI/CD and remote builds. [[1]](diffhunk://#diff-bd18d04181164741121e4163d3a86b67664b0d9b7975fe078a9d747f17b341beR10-R11) [[2]](diffhunk://#diff-bd18d04181164741121e4163d3a86b67664b0d9b7975fe078a9d747f17b341beL18-R41)

**Documentation updates:**

* Updated `README.md` to document the new `OPEN_NEXTJS_NO_INTERACTIVE_PROMPT` variable, including usage examples for CI/CD pipelines and `.env` files. Also added documentation for the existing `NEXT_PRIVATE_DEBUG_CACHE` variable.

**Release note:**

* Added a changeset describing the new feature and its impact, indicating a minor version bump for `@aziontech/opennextjs-azion`.